### PR TITLE
synchronisation fixes for svelte-1-port branch

### DIFF
--- a/src/components/graph/node/NodeWrapper.tsx
+++ b/src/components/graph/node/NodeWrapper.tsx
@@ -41,9 +41,6 @@ const NodeWrapper = <NodeType extends Node = Node>(props: NodeWrapperProps<NodeT
   const node = () => nodeLookup.get(props.nodeId)!;
 
   let prevNodeRef: HTMLDivElement | undefined = undefined;
-  let prevType: string | undefined = undefined;
-  let prevSourcePosition: Position | undefined = undefined;
-  let prevTargetPosition: Position | undefined = undefined;
 
   const nodeId = () => node().id;
   const nodeType = () => node().type ?? "default";
@@ -89,35 +86,40 @@ const NodeWrapper = <NodeType extends Node = Node>(props: NodeWrapperProps<NodeT
     }
   });
 
-  createEffect(() => {
-    // if type, sourcePosition or targetPosition changes,
-    // we need to re-calculate the handle positions
-    const doUpdate = Boolean(
-      (prevType && nodeType() !== prevType) ||
-        (prevSourcePosition && node().sourcePosition !== prevSourcePosition) ||
-        (prevTargetPosition && node().targetPosition !== prevTargetPosition),
-    );
-
-    if (doUpdate) {
-      requestAnimationFrame(() =>
-        updateNodeInternals(
-          new Map([
-            [
-              node().id,
-              {
-                id: node().id,
-                nodeElement: nodeRef()!,
-                force: true,
-              },
-            ],
-          ]),
-        ),
-      );
+  createEffect<{
+    sourcePosition: Position | undefined;
+    targetPosition: Position | undefined;
+    nodeType: string;
+  }>((prev) => {
+    if (
+      prev &&
+      prev.sourcePosition === node().sourcePosition &&
+      prev.targetPosition === node().targetPosition &&
+      prev.nodeType === nodeType()
+    ) {
+      return prev;
     }
 
-    prevType = nodeType();
-    prevSourcePosition = node().sourcePosition;
-    prevTargetPosition = node().targetPosition;
+    const current = {
+      nodeType: nodeType(),
+      sourcePosition: node().sourcePosition,
+      targetPosition: node().targetPosition,
+    };
+
+    updateNodeInternals(
+      new Map([
+        [
+          node().id,
+          {
+            id: node().id,
+            nodeElement: nodeRef()!,
+            force: true,
+          },
+        ],
+      ]),
+    );
+
+    return current;
   });
 
   createEffect(() => {

--- a/src/components/graph/node/NodeWrapper.tsx
+++ b/src/components/graph/node/NodeWrapper.tsx
@@ -100,12 +100,6 @@ const NodeWrapper = <NodeType extends Node = Node>(props: NodeWrapperProps<NodeT
       return prev;
     }
 
-    const current = {
-      nodeType: nodeType(),
-      sourcePosition: node().sourcePosition,
-      targetPosition: node().targetPosition,
-    };
-
     updateNodeInternals(
       new Map([
         [
@@ -119,7 +113,11 @@ const NodeWrapper = <NodeType extends Node = Node>(props: NodeWrapperProps<NodeT
       ]),
     );
 
-    return current;
+    return {
+      nodeType: nodeType(),
+      sourcePosition: node().sourcePosition,
+      targetPosition: node().targetPosition,
+    };
   });
 
   createEffect(() => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,3 +31,9 @@ export const ARROW_KEY_DIFFS: Record<string, XYPosition> = {
   ArrowLeft: { x: -1, y: 0 },
   ArrowRight: { x: 1, y: 0 },
 };
+
+export function deepTrack(value: unknown) {
+  if (typeof value === "object" && value !== null) {
+    Object.values(value).forEach(deepTrack);
+  }
+}


### PR DESCRIPTION
fixes 2 bugs:

1. changes of node-updates in userland are not directly reflected in the nodes
2. when switching handle-orientation, the handle's are re-located, but the connection edges are not updated

## changes of node-updates in userland are not directly reflected in the nodes

Instead of empirically calling adoptUserNodes in the setNode-function, we call it in an effect that deep tracks store.nodes

**before**

```tsx
setNode(...){
   ...
   batch(() => adoptUserNodes(...))
}
```

**after**

```tsx
createEffect(on(() => deepTrack(store.nodes), () => batch(() => adoptUserNodes(...))
```

## when switching handle-orientation, the handle's are re-located, but the connection edges are not updated

Changed the check in the conditional to update internalNodes, also during the initial run.
Refactored the code a bit to not have to keep prev-variables around.