### PR TITLE
fix: fitView should now work correctly

### DIFF
--- a/src/data/defaults.ts
+++ b/src/data/defaults.ts
@@ -34,7 +34,7 @@ export const getDefaultFlowStateProps = <NodeType extends Node, EdgeType extends
     minZoom: 0.5,
     maxZoom: 2,
     selectionMode: "partial" as SelectionMode,
-    fitViewQueued: false,
+    fitView: false,
     noPanClass: "nopan",
     noDragClass: "nodrag",
     noWheelClass: "nowheel",


### PR DESCRIPTION
This PR addresses the issue of `fitView` not working correctly. The control button now works the way it should.

There is still more to do here as this perhaps is revealing a higher order problem for us to address regarding `nodesInitialized` which should be invoking the `fitView` functionality on component mount which we do not incorporate currently due to triggering an infinite reactive loop thanks to what I believe is caused by the ReactiveMap objects we're using.