### PR TITLE
fix: add resize observer for solid-flow root container

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@solid-primitives/map": "^0.7.2",
         "@solid-primitives/media": "^2.3.3",
+        "@solid-primitives/resize-observer": "^2.1.3",
         "clsx": "^2.1.1",
       },
       "devDependencies": {
@@ -254,6 +255,8 @@
     "@solid-primitives/map": ["@solid-primitives/map@0.7.2", "", { "dependencies": { "@solid-primitives/trigger": "^1.2.2" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-sXK/rS68B4oq3XXNyLrzVhLtT1pnimmMUahd2FqhtYUuyQsCfnW058ptO1s+lWc2k8F/3zQSNVkZ2ifJjlcNbQ=="],
 
     "@solid-primitives/media": ["@solid-primitives/media@2.3.3", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.3", "@solid-primitives/rootless": "^1.5.2", "@solid-primitives/static-store": "^0.1.2", "@solid-primitives/utils": "^6.3.2" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-hQ4hLOGvfbugQi5Eu1BFWAIJGIAzztq9x0h02xgBGl2l0Jaa3h7tg6bz5tV1NSuNYVGio4rPoa7zVQQLkkx9dA=="],
+
+    "@solid-primitives/resize-observer": ["@solid-primitives/resize-observer@2.1.3", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.3", "@solid-primitives/rootless": "^1.5.2", "@solid-primitives/static-store": "^0.1.2", "@solid-primitives/utils": "^6.3.2" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-zBLje5E06TgOg93S7rGPldmhDnouNGhvfZVKOp+oG2XU8snA+GoCSSCz1M+jpNAg5Ek2EakU5UVQqL152WmdXQ=="],
 
     "@solid-primitives/rootless": ["@solid-primitives/rootless@1.5.2", "", { "dependencies": { "@solid-primitives/utils": "^6.3.2" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-9HULb0QAzL2r47CCad0M+NKFtQ+LrGGNHZfteX/ThdGvKIg2o2GYhBooZubTCd/RTu2l2+Nw4s+dEfiDGvdrrQ=="],
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "@solid-primitives/map": "^0.7.2",
     "@solid-primitives/media": "^2.3.3",
+    "@solid-primitives/resize-observer": "^2.1.3",
     "clsx": "^2.1.1"
   },
   "main": "./dist/index/index.js",

--- a/src/components/SolidFlow/component.tsx
+++ b/src/components/SolidFlow/component.tsx
@@ -1,3 +1,4 @@
+import { createResizeObserver } from "@solid-primitives/resize-observer";
 import { type ColorModeClass, infiniteExtent, isMacOs } from "@xyflow/system";
 import clsx from "clsx";
 import {
@@ -225,10 +226,12 @@ export const SolidFlow = <NodeType extends Node = Node, EdgeType extends Edge = 
   onMount(() => {
     batch(() => {
       actions.setConfig(_props);
-      // NOTE: should we check here if we have explicitly provided a width/height via props?
+      actions.setDomNode(domNode);
+    });
+
+    createResizeObserver(domNode, () => {
       actions.setWidth(domNode.clientWidth);
       actions.setHeight(domNode.clientHeight);
-      actions.setDomNode(domNode);
     });
 
     createEffect(() => {

--- a/src/data/createSolidFlow.tsx
+++ b/src/data/createSolidFlow.tsx
@@ -17,6 +17,7 @@ import {
   getNodePositionWithOrigin,
   getViewportForBounds,
   type Handle,
+  type HandleConnection,
   infiniteExtent,
   initialConnection,
   type InternalNodeBase,
@@ -41,7 +42,6 @@ import {
   type Viewport,
   type ViewportHelperFunctionOptions,
   type XYPosition,
-  type HandleConnection,
 } from "@xyflow/system";
 import {
   batch,


### PR DESCRIPTION
## Summary

This PR addresses this reported [issue](https://github.com/dsnchz/solid-flow/issues/6).

## AI Summary

This pull request enhances the responsiveness of the `SolidFlow` component by introducing automatic size updates when its container is resized. The main change is the integration of a resize observer to monitor the component's DOM node and update its width and height accordingly.

**Responsive behavior improvements:**

* Added the `@solid-primitives/resize-observer` dependency to `package.json` to enable resize observation functionality.
* Imported `createResizeObserver` from `@solid-primitives/resize-observer` in `src/components/SolidFlow/component.tsx`.
* Refactored the `onMount` logic in `SolidFlow` to use `createResizeObserver` for automatically updating width and height when the DOM node is resized, improving the component's adaptability to layout changes.